### PR TITLE
Update perf.py

### DIFF
--- a/build/lib/scorecardpy/perf.py
+++ b/build/lib/scorecardpy/perf.py
@@ -459,7 +459,7 @@ def perf_psi(score, label=None, title=None, x_limits=None, x_tick_break=50, show
         if label is not None:
             score[i].loc[:,'y'] = label[i]
         else:
-            score[i].copy(deep=True).loc[:,'y'] = np.nan
+            score[i].loc[:,'y'] = np.nan
     # dateset of score and label
     dt_sl = pd.concat(score, names=['ae', 'rowid']).reset_index()\
       .sample(frac=1, random_state=seed)


### PR DESCRIPTION
score[i].copy(deep=True).loc[:,'y'] = np.nan      Change to      score[i].loc[:,'y'] = np.nan
#462I think you should delete '.copy(deep=True) '.If you follow the source code and enter 'label=None' in the perf_psi function, the function returns an error indicating that the label column 'y' cannot be found. The code will not return an error unless you delete this'.copy(deep=True) '.