### PR TITLE
Update woebin.py

### DIFF
--- a/scorecardpy/woebin.py
+++ b/scorecardpy/woebin.py
@@ -856,6 +856,8 @@ def woebin(dt, y, x=None, breaks_list=None, special_values=None,
     dt = rep_blank_na(dt)
     # check y
     dt = check_y(dt, y, positive)
+    # change boolean variables
+    dt[dt.select_dtypes(['object', 'bool']).columns.tolist()] = dt.select_dtypes(['object', 'bool']).astype('str')
     # x variable names
     xs = x_variable(dt,y,x)
     xs_len = len(xs)


### PR DESCRIPTION
如果某一列数据是，布尔型数据列，dtype=bool，那么将会报错;
或者如果某一列的数据是，True/False/NA，会被pandas之别为dtype=object，这也会报错。
这两种情况的错误都是：
TypeError                                 Traceback (most recent call last)
<ipython-input-65-a6451297907e> in <module>()
      1 # woe binning ------
----> 2 data_bins1 = sc.woebin(data_s1, y="d0")

~/anaconda3/lib/python3.6/site-packages/scorecardpy/woebin.py in woebin(dt, y, x, breaks_list, special_values, min_perc_fine_bin, min_perc_coarse_bin, stop_limit, max_num_bin, positive, no_cores, print_step, method)
    891         )
    892         # bins in dictionary
--> 893         bins = dict(zip(xs, pool.starmap(woebin2, args)))
    894         pool.close()
    895 

~/anaconda3/lib/python3.6/multiprocessing/pool.py in starmap(self, func, iterable, chunksize)
    272         `func` and (a, b) becomes func(a, b).
    273         '''
--> 274         return self._map_async(func, iterable, starmapstar, chunksize).get()
    275 
    276     def starmap_async(self, func, iterable, chunksize=None, callback=None,

~/anaconda3/lib/python3.6/multiprocessing/pool.py in get(self, timeout)
    642             return self._value
    643         else:
--> 644             raise self._value
    645 
    646     def _set(self, i, obj):

TypeError: sequence item 0: expected str instance, bool found。
---------------------------------------------------------------------------------------
所以这里要先将，对象型或者布尔型数据，转化成字符串。
如果有什么不对的地方，希望谢老师指出来~