### PR TITLE
Update var_filter.py

### DIFF
--- a/scorecardpy/var_filter.py
+++ b/scorecardpy/var_filter.py
@@ -68,6 +68,8 @@ def var_filter(dt, y, x=None, iv_limit=0.02, missing_limit=0.95,
     dt = rmcol_datetime_unique1(dt)
     # replace "" by NA
     dt = rep_blank_na(dt)
+    # change boolean variables
+    dt[dt.select_dtypes(['object', 'bool']).columns.tolist()] = dt.select_dtypes(['object', 'bool']).astype('str')
     # check y
     dt = check_y(dt, y, positive)
     # x variable names


### PR DESCRIPTION
我直接在var_filter.py的文件里改了。
这样就可以避免，‘’如果有布尔列或者含有布尔列的数据时，生成列表时会出错的情况。‘’
我也已经测试过了。missing的情况不影响呀。
~~~因为我这里，只是仅仅在数据处理的开始，将对象型和布尔型数据，转换成字符串式的对象型数据。对于整体的函数运行应该没影响。
~~~并且，对于离散型数据的分箱，标准数据类型应该就是字符串吧?~
希望谢老师有空看看哈~~~如果想法不对，希望谢老师能够指正。