### PR TITLE
update_woebin.py: solution：error in pandas Version: 0.24.2

### DIFF
--- a/scorecardpy/woebin.py
+++ b/scorecardpy/woebin.py
@@ -986,8 +986,7 @@ def woepoints_ply1(dtx, binx, x_i, woe_points):
     if not is_string_dtype(dtx[x_i]):
         dtx.loc[:,x_i] = dtx.loc[:,x_i].astype(str).replace('nan', 'missing')
     # dtx.loc[:,x_i] = np.where(pd.isnull(dtx[x_i]), dtx[x_i], dtx[x_i].astype(str))
-    # dtx = dtx.replace(np.nan, 'missing').assign(rowid = dtx.index)
-    dtx = dtx.fillna('missing').assign(rowid = dtx.index).sort_values('rowid')
+    dtx = dtx.replace(np.nan, 'missing').assign(rowid = dtx.index).sort_values('rowid')
     # rename binx
     binx.columns = ['bin', x_i, '_'.join([x_i,woe_points])]
     # merge


### PR DESCRIPTION
如果将pandas更新到最新版本0.24.2，运行sc.woebin_ply(train, bins)将会报错：ValueError: fill value must be in categories pandas Version: 0.24.2。
主要因为dtx = dtx.fillna('missing').assign(rowid = dtx.index)这行代码，在0.24.2版本下不兼容。但解决这个问题比较麻烦，所以另辟蹊径。
换了条代码：dtx = dtx.replace(np.nan, 'missing').assign(rowid = dtx.index).sort_values('rowid')可以解决。
也是谢老师加注释的一条，看来确实有先见哈哈。