### PR TITLE
Update condition_fun.py:The date column's dtype is object, the function doesn't work

### DIFF
--- a/scorecardpy/condition_fun.py
+++ b/scorecardpy/condition_fun.py
@@ -35,7 +35,8 @@ def rmcol_datetime_unique1(dat, check_char_num = False): # add more datatime typ
         dat=dat.drop(unique1_cols, axis=1)
     
     # remove date time variable # isinstance
-    datetime_cols = dat.dtypes[dat.dtypes == 'datetime64[ns]'].index.tolist()
+    dat_time = dat.apply(pd.to_numeric,errors='ignore').select_dtypes(object).apply(pd.to_datetime,errors='ignore')
+    datetime_cols = dat_time.dtypes[dat_time.dtypes == 'datetime64[ns]'].index.tolist()
     if len(datetime_cols) > 0:
         warnings.warn("There are {} date/time type columns are removed from input dataset. \n (ColumnNames: {})".format(len(datetime_cols), ', '.join(datetime_cols)))
         dat=dat.drop(datetime_cols, axis=1)


### PR DESCRIPTION
在condition_fun.py文件中，移除日期列的函数rmcol_datetime_unique1，其实不能移除被识为object的日期列，比如日期列别读成了字符串。
我的这里的更改，将所有能转为成日期的object列转换成了datetime64[ns]列。
我的更改通过了验证，且能够完全删除日期列。