### PR TITLE
Add a yes/no question when using multiprocessing module on Windows platform. 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/shichenxie/anaconda3/bin/python"
-}

--- a/scorecardpy/woebin.py
+++ b/scorecardpy/woebin.py
@@ -10,6 +10,7 @@ import multiprocessing as mp
 import matplotlib.pyplot as plt
 import time
 import os
+import sys
 import platform
 from .condition_fun import *
 from .info_value import *
@@ -941,7 +942,7 @@ def woebin(dt, y, x=None,
             print('WARNING: To use multi-core computation on Windows, make sure your main module was safely imported using "if __name__ == \'__main__\'"')
             join=input('Are you sure to move on?[Y/N]')
             if join.lower() != 'y':
-                os._exit()
+                sys.exit(0)
         else:
             no_cores = 1
     
@@ -1138,7 +1139,7 @@ def woebin_ply(dt, bins, no_cores=None, print_step=0, replace_blank=True, **kwar
             print('WARNING: To use multi-core computation on Windows, make sure your main module was safely imported using "if __name__ == \'__main__\'"')
             join=input('Are you sure to move on?[Y/N]')
             if join.lower() != 'y':
-                os._exit()
+                sys.exit(0)
         else:
             no_cores = 1
     

--- a/scorecardpy/woebin.py
+++ b/scorecardpy/woebin.py
@@ -936,11 +936,19 @@ def woebin(dt, y, x=None,
     ### ### 
     # binning for each x variable
     # loop on xs
-    if (no_cores is None) or (no_cores < 1):
-        all_cores = mp.cpu_count() - 1
-        no_cores = int(np.ceil(xs_len/5 if xs_len/5 < all_cores else all_cores*0.9))
-    if platform.system() == 'Windows': 
-        no_cores = 1
+    if platform.system() == 'Windows':
+        if (no_cores is not None) and (no_cores > 1):
+            print('WARNING: To use multi-core computation on Windows, make sure your main module was safely imported using "if __name__ == \'__main__\'"')
+            join=input('Are you sure to move on?[Y/N]')
+            if join.lower() != 'y':
+                os._exit()
+        else:
+            no_cores = 1
+    
+    else:
+        if (no_cores is None) or (no_cores < 1):
+            all_cores = mp.cpu_count() - 1
+            no_cores = int(np.ceil(xs_len/5 if xs_len/5 < all_cores else all_cores*0.9))
             
     # ylist to str
     y = y[0]
@@ -1125,12 +1133,21 @@ def woebin_ply(dt, bins, no_cores=None, print_step=0, replace_blank=True, **kwar
     dat = dt.loc[:,list(set(xs_dt) - set(xs))]
     
     # loop on xs
-    if (no_cores is None) or (no_cores < 1):
-        all_cores = mp.cpu_count() - 1
-        no_cores = int(np.ceil(xs_len/5 if xs_len/5 < all_cores else all_cores*0.9))
-    if platform.system() == 'Windows': 
-        no_cores = 1 
-            
+    if platform.system() == 'Windows':
+        if (no_cores is not None) and (no_cores > 1):
+            print('WARNING: To use multi-core computation on Windows, make sure your main module was safely imported using "if __name__ == \'__main__\'"')
+            join=input('Are you sure to move on?[Y/N]')
+            if join.lower() != 'y':
+                os._exit()
+        else:
+            no_cores = 1
+    
+    else:
+        if (no_cores is None) or (no_cores < 1):
+            all_cores = mp.cpu_count() - 1
+            no_cores = int(np.ceil(xs_len/5 if xs_len/5 < all_cores else all_cores*0.9))            
+
+
     # 
     if no_cores == 1:
         for i in np.arange(xs_len):


### PR DESCRIPTION
背景：在Windows平台下，使用multiprocessing多进程模块的程序必须由if __name__ == '__main__'安全导入才能使用。

在weobin.py中新添加向使用者确认的提问程序：
- 当检测到环境为Windows，且使用者自定义了no_cores时，程序发出y/n问题，向用户确认是否由main安全导入
- 环境为Windows，但使用者没有定义no_cores或定义为1时，用单核运行
- 其它平台与原本逻辑相同

其实实用价值不高，但尚未找到更好的方法，看看要不要加上