### PR TITLE
Relative import of sub-modules

### DIFF
--- a/scorecardpy/__init__.py
+++ b/scorecardpy/__init__.py
@@ -1,15 +1,15 @@
 # -*- coding:utf-8 -*- 
 
-from scorecardpy.germancredit import germancredit
-from scorecardpy.split_df import split_df
-from scorecardpy.info_value import iv
+from .germancredit import germancredit
+from .split_df import split_df
+from .info_value import iv
 # from .info_ent_indx_gini import (ig, ie)
-from scorecardpy.var_filter import var_filter
-from scorecardpy.woebin import (woebin, woebin_ply, woebin_plot, woebin_adj)
-from scorecardpy.perf import (perf_eva, perf_psi)
-from scorecardpy.scorecard import (scorecard, scorecard_ply)
-from scorecardpy.one_hot import one_hot
-from scorecardpy.vif import vif
+from .var_filter import var_filter
+from .woebin import (woebin, woebin_ply, woebin_plot, woebin_adj)
+from .perf import (perf_eva, perf_psi)
+from .scorecard import (scorecard, scorecard_ply)
+from .one_hot import one_hot
+from .vif import vif
 
 
 __version__ = '0.1.9.3'


### PR DESCRIPTION
Hi!
Sometimes I need to keep different versions of scorecardpy with some modifications at the same place, e.g. 'sorecardpy_019', 'sorecardpy_0193ab' etc. To make this possible the sub-modules must be imported in '__init__.py' by a local path. That's this trivial fix as about.